### PR TITLE
register me

### DIFF
--- a/Demo/CCNavTab/Classes/One/OneController.m
+++ b/Demo/CCNavTab/Classes/One/OneController.m
@@ -13,6 +13,7 @@
 
 @property (nonatomic, strong) NSMutableArray *arrayM;
 
+
 @end
 
 @implementation OneController


### PR DESCRIPTION
添加支持 StoryBoard  

 在 CCTabBarController.h
   改变#define  VIEWCONTROLLER --> VC_VIEWCONTROLLER
    添加 #define     VC_STORYBOARD

在 QLSTabBarController.m   

   setChildControllerAndIconArr 方法中

   if ([dict objectForKey:VC_VIEWCONTROLLER]) {
            nav=[[CCNavigationController alloc]initWithRootViewController:[dict objectForKey:VC_VIEWCONTROLLER]];
        }
        if ([dict objectForKey:VC_STORYBOARD]) {

```
        UIStoryboard *sb = [UIStoryboard storyboardWithName:[dict objectForKey:VC_STORYBOARD] bundle:[NSBundle mainBundle]];

        UIViewController *vc = [sb instantiateViewControllerWithIdentifier:[dict objectForKey:VC_STORYBOARD]];

        nav = [[CCNavigationController alloc]initWithRootViewController:vc];
    }
```
